### PR TITLE
fix: isolate hook events per name and fix emote parsing with space→quote

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -371,9 +371,8 @@ var COMMANDS = {
 	},
 
 	emote: function (args, raw) {
-		if (nickIgnored(args.text.match(/@(.+?)(?: .+)/)[1])) {
-			return
-		}
+        let nick = args.text.match(/@([^\s']+)/)?.[1];
+        if (nick && nickIgnored(nick)) return;
 		args.nick = '*'
 		pushMessage(args, { i18n: false, raw })
 	},

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -1,10 +1,8 @@
 var hooks = {};
-const defaultHook = { "before": [], "in": [], "after": [] };
-
 var hook = {
     register: function (when, name, func) {
         if (!hooks[name]) {
-            hooks[name] = { ...defaultHook };
+            hooks[name] = { before: [], in: [], after: [] };
         }
         hooks[name][when].push(func);
     },


### PR DESCRIPTION
**What**
- 修复 hooks 不同 name 共用事件数组
- 修复 emote 中空格变单引号导致解析失败

**Why**
- hooks: 浅拷贝导致数组引用共享
- emote: 原正则不匹配 `'`

**How**
- hooks: 直接创建 `{ before: [], in: [], after: [] }`
- emote: 正则改为 `@([^\s']+)`，条件改为 `if (match && nickIgnored(match[1])) return;`